### PR TITLE
Mark json_cleanup a stock.

### DIFF
--- a/addons/sourcemod/scripting/include/json.inc
+++ b/addons/sourcemod/scripting/include/json.inc
@@ -393,7 +393,7 @@ stock JSON_Object json_decode(const char[] buffer, JSON_Object result = null, in
  *
  * @param obj JSON_Object to clean up.
  */
-void json_cleanup(JSON_Object obj) {
+stock void json_cleanup(JSON_Object obj) {
     bool is_array = obj.IsArray;
 
     int key_length = 0;


### PR DESCRIPTION
Otherwise some users that include json.inc may get "unused function" warnings, e.g. https://travis-ci.org/splewis/get5/jobs/587178899.

(I'm relying on the CI build to make sure this compiles, hopefully it does!)