### PR TITLE
Fix changing compiler settings for consumers

### DIFF
--- a/addons/sourcemod/scripting/include/json.inc
+++ b/addons/sourcemod/scripting/include/json.inc
@@ -36,9 +36,6 @@
 #endif
 #define _json_included
 
-#pragma semicolon 1
-#pragma newdecls required
-
 #include <string>
 #include <json/definitions>
 #include <json/helpers/decode>

--- a/addons/sourcemod/scripting/include/json/definitions.inc
+++ b/addons/sourcemod/scripting/include/json/definitions.inc
@@ -36,9 +36,6 @@
 #endif
 #define _json_definitions_included
 
-#pragma semicolon 1
-#pragma newdecls required
-
 #include <string>
 #include <json/helpers/string>
 

--- a/addons/sourcemod/scripting/include/json/helpers/decode.inc
+++ b/addons/sourcemod/scripting/include/json/helpers/decode.inc
@@ -36,9 +36,6 @@
 #endif
 #define _json_helpers_decode_included
 
-#pragma semicolon 1
-#pragma newdecls required
-
 #include <string>
 
 /**

--- a/addons/sourcemod/scripting/include/json/helpers/encode.inc
+++ b/addons/sourcemod/scripting/include/json/helpers/encode.inc
@@ -36,9 +36,6 @@
 #endif
 #define _json_helpers_encode_included
 
-#pragma semicolon 1
-#pragma newdecls required
-
 #include <string>
 
 /**

--- a/addons/sourcemod/scripting/include/json/helpers/string.inc
+++ b/addons/sourcemod/scripting/include/json/helpers/string.inc
@@ -36,9 +36,6 @@
 #endif
 #define _json_helpers_string_included
 
-#pragma semicolon 1
-#pragma newdecls required
-
 /**
  * Checks if a string starts with another string.
  *

--- a/addons/sourcemod/scripting/include/json/object.inc
+++ b/addons/sourcemod/scripting/include/json/object.inc
@@ -36,9 +36,6 @@
 #endif
 #define _json_object_included
 
-#pragma semicolon 1
-#pragma newdecls required
-
 #include <string>
 #include <json/definitions>
 #include <json/helpers/encode>

--- a/addons/sourcemod/scripting/json_test.sp
+++ b/addons/sourcemod/scripting/json_test.sp
@@ -32,10 +32,12 @@
  */
 
 #include <sourcemod>
-#include <json>
 
 #pragma semicolon 1
 #pragma newdecls required
+
+// Include our own include after setting compiler settings, to ensure we conform.
+#include <json>
 
 public Plugin myinfo = {
     name = "JSON Tester",


### PR DESCRIPTION
`#pragma` is not intended for use in include files and breaks compiler
descisions made by users. Instead, include our own files after changing
the settings in the base plugin to ensure they're tested by CI.

See https://forums.alliedmods.net/showthread.php?t=318888