### PR TITLE
Fix SM 1.8 compilation

### DIFF
--- a/addons/sourcemod/scripting/include/json.inc
+++ b/addons/sourcemod/scripting/include/json.inc
@@ -646,7 +646,8 @@ stock void json_cleanup(JSON_Object obj)
     delete snap;
 
     if (obj.IsArray) {
-        view_as<JSON_Array>(obj).Clear();
+        JSON_Array obj_arr = view_as<JSON_Array>(obj);
+	obj_arr.Clear();
     } else {
         obj.Clear();
     }

--- a/addons/sourcemod/scripting/include/json.inc
+++ b/addons/sourcemod/scripting/include/json.inc
@@ -647,7 +647,7 @@ stock void json_cleanup(JSON_Object obj)
 
     if (obj.IsArray) {
         JSON_Array obj_arr = view_as<JSON_Array>(obj);
-	obj_arr.Clear();
+        obj_arr.Clear();
     } else {
         obj.Clear();
     }


### PR DESCRIPTION
Attempt to use this library with sourcemod 1.8.x ends up with following error

```bash
Compiling /tmp/sources/shopsms.sp ... /tmp/addons/sourcemod/scripting/include/json.inc(649) : error 001: expected token: ";", but found "."
/tmp/addons/sourcemod/scripting/include/json.inc(649) : error 029: invalid expression, assumed zero
/tmp/addons/sourcemod/scripting/include/json.inc(649) : error 017: undefined symbol "Clear"
/tmp/addons/sourcemod/scripting/include/json.inc(649) : fatal error 189: too many error messages on one line
```

This PR fixes that issue.