### PR TITLE
Preserve ordered keys on object copy

### DIFF
--- a/addons/sourcemod/scripting/include/json.inc
+++ b/addons/sourcemod/scripting/include/json.inc
@@ -733,6 +733,9 @@ stock JSON_Object json_copy_shallow(JSON_Object obj)
     if (isArray) {
         view_as<JSON_Array>(result).Concat(view_as<JSON_Array>(obj));
     } else {
+        if (obj.OrderedKeys) {
+            result.EnableOrderedKeys();
+        }
         result.Merge(obj);
     }
 


### PR DESCRIPTION
Should fix https://github.com/clugg/sm-json/issues/30 as far as I can tell.