### PR TITLE
Support copying objects with `null` keys + support deep array concat + fix wrong hidden key index when concat'ting arrays

### DIFF
--- a/addons/sourcemod/scripting/include/json.inc
+++ b/addons/sourcemod/scripting/include/json.inc
@@ -767,7 +767,7 @@ stock JSON_Object json_copy_deep(JSON_Object obj)
         }
 
         JSON_Object value = obj.GetObject(key);
-        result.SetObject(key, json_copy_deep(value));
+        result.SetObject(key, value != null ? json_copy_deep(value) : null);
     }
 
     return result;

--- a/addons/sourcemod/scripting/include/json/array.inc
+++ b/addons/sourcemod/scripting/include/json/array.inc
@@ -750,12 +750,13 @@ methodmap JSON_Array < JSON_Object
      * on to the end of this array.
      *
      * @param from      Array to concat entries from.
+     * @param deepCopy  Whether objects should be deep copied from the source array.
      * @return          True on success, false otherwise.
      * @error           If the object being merged is an object or the
      *                  arrays being merged don't have the same strict
      *                  type set, an error will be thrown.
      */
-    public bool Concat(JSON_Array from)
+    public bool Concat(JSON_Array from, bool deepCopy = false)
     {
         if (! this.IsArray || ! from.IsArray) {
             json_set_last_error("attempted to concat using object(s)");
@@ -772,6 +773,7 @@ methodmap JSON_Array < JSON_Object
         }
 
         int json_size = from.Length;
+        int current_size = this.Length;
         for (int i = 0; i < json_size; i += 1) {
             JSONCellType type = from.GetType(i);
             // skip keys of unknown type
@@ -805,11 +807,11 @@ methodmap JSON_Array < JSON_Object
                     this.PushBool(from.GetBool(i));
                 }
                 case JSON_Type_Object: {
-                    this.PushObject(from.GetObject(i));
+                    this.PushObject(deepCopy ? from.GetObject(i).DeepCopy() : from.GetObject(i));
                 }
             }
 
-            this.SetHidden(json_size + i, from.GetHidden(i));
+            this.SetHidden(current_size + i, from.GetHidden(i));
         }
 
         return true;

--- a/addons/sourcemod/scripting/include/json/object.inc
+++ b/addons/sourcemod/scripting/include/json/object.inc
@@ -406,7 +406,7 @@ methodmap JSON_Object < MetaStringMap
      * Retrieves the int64 stored at a key.
      *
      * @param key               Key to retrieve int64 value for.
-     * @param default_value     Value to return if the key does not exist.
+     * @param value             Value to store the int array in.
      * @return                  Value stored at key.
      */
     public bool GetInt64(const char[] key, int value[2])

--- a/addons/sourcemod/scripting/json_test.sp
+++ b/addons/sourcemod/scripting/json_test.sp
@@ -439,6 +439,25 @@ void it_should_support_arrays_nested_in_arrays()
     json_cleanup_and_delete(arr);
 }
 
+void it_should_copy_null_keys()
+{
+    JSON_Object original = new JSON_Object();
+    original.SetObject("null_key", null);
+    original.SetString("non_null_key", "test_value");
+
+    JSON_Object copy = original.DeepCopy();
+    copy.SetString("non_null_key", "test_value_2");
+
+    _json_encode(original, JSON_ENCODE_PRETTY);
+    Test_AssertStringsEqual("output null copy original", json_encode_output, "{\"non_null_key\":\"test_value\",\"null_key\":null}");
+
+    _json_encode(copy, JSON_ENCODE_PRETTY);
+    Test_AssertStringsEqual("output null copy copy", json_encode_output, "{\"non_null_key\":\"test_value_2\",\"null_key\":null}");
+
+    json_cleanup_and_delete(original);
+    json_cleanup_and_delete(copy);
+}
+
 void it_should_support_basic_methodmaps()
 {
     Player player = new Player();
@@ -1273,6 +1292,7 @@ public void OnPluginStart()
     Test_Run("it_should_concat_arrays", it_should_concat_arrays);
     Test_Run("it_should_copy_flat_arrays", it_should_copy_flat_arrays);
     Test_Run("it_should_copy_flat_objects", it_should_copy_flat_objects);
+    Test_Run("it_should_copy_null_keys", it_should_copy_null_keys);
     Test_Run("it_should_shallow_copy_arrays", it_should_shallow_copy_arrays);
     Test_Run("it_should_shallow_copy_objects", it_should_shallow_copy_objects);
     Test_Run("it_should_preserve_ordered_keys_on_shallow_copy", it_should_preserve_ordered_keys_on_shallow_copy);


### PR DESCRIPTION
Hello again

It would seem the library does not like it when you attempt to copy objects with `null` keys in them. This happens:

```c++
JSON_Object json = new JSON_Object();
json.SetObject("null_key", null);
json.SetString("non_null_key", "test_value");
JSON_Object copy = json.DeepCopy();
```

```log
L 03/21/2023 - 02:35:53: [SM] Exception reported: Invalid Handle 0 (error 4)
L 03/21/2023 - 02:35:53: [SM] Blaming: theplugin.smx
L 03/21/2023 - 02:35:53: [SM] Call stack trace:
L 03/21/2023 - 02:35:53: [SM]   [0] StringMap.GetValue
L 03/21/2023 - 02:35:53: [SM]   [1] Line 98, addons/sourcemod/scripting/include/json/helpers/typedstringmap.inc::TypedStringMap.GetOptionalValue
L 03/21/2023 - 02:35:53: [SM]   [2] Line 136, addons/sourcemod/scripting/include/json/helpers/typedstringmap.inc::TypedStringMap.GetBool
L 03/21/2023 - 02:35:53: [SM]   [3] Line 67, addons/sourcemod/scripting/include/json/object.inc::JSON_Object.IsArray.get
L 03/21/2023 - 02:35:53: [SM]   [4] Line 728, addons/sourcemod/scripting/include/json.inc::json_copy_shallow
L 03/21/2023 - 02:35:53: [SM]   [5] Line 754, addons/sourcemod/scripting/include/json.inc::json_copy_deep
L 03/21/2023 - 02:35:53: [SM]   [6] Line 770, addons/sourcemod/scripting/include/json.inc::json_copy_deep
L 03/21/2023 - 02:35:53: [SM]   [7] Line 758, addons/sourcemod/scripting/include/json/object.inc::JSON_Object.DeepCopy
```

This PR should fix that, as far as I can tell. Let me know if I misunderstood anything here. I'm not 100% sure this is the best approach for it, but at least it works.

I wrote out a test for it "by hand", but I didn't run/compile it, because I don't have the tools handy for it (I only ever compile Get5 with Docker), so you better give it a go.