### PR TITLE
Fix `DeepCopy` problems for objects with ordered keys to prevent snapshot leaks on copy

### DIFF
--- a/addons/sourcemod/scripting/include/json.inc
+++ b/addons/sourcemod/scripting/include/json.inc
@@ -175,7 +175,7 @@ stock void json_encode(
     strcopy(output, max_size, is_array ? "[" : "{");
 
     // used in key iterator
-    int json_size = obj.Iterate();
+    int json_size = is_array ? obj.Length : obj.Iterate();
     int builder_size = 0;
     int str_length = 1;
     JSON_Object child = null;
@@ -751,23 +751,68 @@ stock JSON_Object json_copy_shallow(JSON_Object obj)
  */
 stock JSON_Object json_copy_deep(JSON_Object obj)
 {
-    JSON_Object result = json_copy_shallow(obj);
+    bool isArray = obj.IsArray;
+    JSON_Object result = isArray
+        ? view_as<JSON_Object>(new JSON_Array())
+        : new JSON_Object();
 
-    int length = obj.Iterate();
-    int key_length = 0;
-    for (int i = 0; i < length; i += 1) {
-        key_length = obj.GetKeySize(i);
-        char[] key = new char[key_length];
-        obj.GetKey(i, key, key_length);
-
-        // only deep copy objects
-        JSONCellType type = obj.GetType(key);
-        if (type != JSON_Type_Object) {
-            continue;
+    if (isArray) {
+        view_as<JSON_Array>(result).Concat(view_as<JSON_Array>(obj));
+    } else {
+        if (obj.OrderedKeys) {
+            result.EnableOrderedKeys();
         }
+    }
 
-        JSON_Object value = obj.GetObject(key);
-        result.SetObject(key, value != null ? json_copy_deep(value) : null);
+    if (result.IsArray) {
+        JSON_Array arr = view_as<JSON_Array>(result);
+        JSON_Array objA = view_as<JSON_Array>(obj);
+        int length = arr.Length;
+        for (int i = 0; i < length; i++) {
+            JSONCellType type = objA.GetType(i);
+            if (type != JSON_Type_Object) {
+              continue;
+            }
+            JSON_Object value = objA.GetObject(i);
+            arr.SetObject(i, value != null ? value.DeepCopy() : null);
+        }
+    } else {
+        int length = obj.Iterate();
+        int key_length = 0;
+        for (int i = 0; i < length; i += 1) {
+            key_length = obj.GetKeySize(i);
+            char[] key = new char[key_length];
+            obj.GetKey(i, key, key_length);
+            JSONCellType type = obj.GetType(key);
+            switch (type) {
+                case JSON_Type_String: {
+                    int kl = obj.GetSize(key);
+                    char[] value = new char[kl];
+                    obj.GetString(key, value, kl);
+                    result.SetString(key, value);
+                }
+                case JSON_Type_Int: {
+                    result.SetInt(key, obj.GetInt(key));
+                }
+                #if SM_INT64_SUPPORTED
+                case JSON_Type_Int64: {
+                    int value[2];
+                    obj.GetInt64(key, value);
+                    result.SetInt64(key, value);
+                }
+                #endif
+                case JSON_Type_Float: {
+                    result.SetFloat(key, obj.GetFloat(key));
+                }
+                case JSON_Type_Bool: {
+                    result.SetBool(key, obj.GetBool(key));
+                }
+                case JSON_Type_Object: {
+                    JSON_Object value = obj.GetObject(key);
+                    result.SetObject(key, value != null ? json_copy_deep(value) : null);
+                }
+            }
+        }
     }
 
     return result;
@@ -784,22 +829,39 @@ stock void json_cleanup(JSON_Object obj)
         return;
     }
 
-    int length = obj.Iterate();
-    int key_length = 0;
-    for (int i = 0; i < length; i += 1) {
-        key_length = obj.GetKeySize(i);
-        char[] key = new char[key_length];
-        obj.GetKey(i, key, key_length);
+    if (obj.IsArray) {
+        JSON_Array arr = view_as<JSON_Array>(obj);
+        int length = arr.Length;
+        for (int i = 0; i < length; i++) {
 
-        // only clean up objects
-        JSONCellType type = obj.GetType(key);
-        if (type != JSON_Type_Object) {
-            continue;
+            JSONCellType type = arr.GetType(i);
+            if (type != JSON_Type_Object) {
+              continue;
+            }
+
+            JSON_Object value = arr.GetObject(i);
+            if (value != null) {
+              json_cleanup(value);
+            }
         }
+    } else {
+        int length = obj.Iterate();
+        int key_length = 0;
+        for (int i = 0; i < length; i += 1) {
+            key_length = obj.GetKeySize(i);
+            char[] key = new char[key_length];
+            obj.GetKey(i, key, key_length);
 
-        JSON_Object value = obj.GetObject(key);
-        if (value != null) {
-            json_cleanup(value);
+            // only clean up objects
+            JSONCellType type = obj.GetType(key);
+            if (type != JSON_Type_Object) {
+                continue;
+            }
+
+            JSON_Object value = obj.GetObject(key);
+            if (value != null) {
+                json_cleanup(value);
+            }
         }
     }
 

--- a/addons/sourcemod/scripting/include/json.inc
+++ b/addons/sourcemod/scripting/include/json.inc
@@ -767,7 +767,7 @@ stock JSON_Object json_copy_deep(JSON_Object obj)
         }
 
         JSON_Object value = obj.GetObject(key);
-        result.SetObject(key, json_copy_deep(value));
+        result.SetObject(key, value != null ? json_copy_deep(value) : null);
     }
 
     return result;

--- a/addons/sourcemod/scripting/include/json/array.inc
+++ b/addons/sourcemod/scripting/include/json/array.inc
@@ -750,12 +750,13 @@ methodmap JSON_Array < JSON_Object
      * on to the end of this array.
      *
      * @param from      Array to concat entries from.
+     * @param deepCopy  Whether objects should be deep copied from the source array.
      * @return          True on success, false otherwise.
      * @error           If the object being merged is an object or the
      *                  arrays being merged don't have the same strict
      *                  type set, an error will be thrown.
      */
-    public bool Concat(JSON_Array from)
+    public bool Concat(JSON_Array from, bool deepCopy = false)
     {
         if (! this.IsArray || ! from.IsArray) {
             json_set_last_error("attempted to concat using object(s)");
@@ -772,6 +773,7 @@ methodmap JSON_Array < JSON_Object
         }
 
         int json_size = from.Length;
+        int current_size = this.Length;
         for (int i = 0; i < json_size; i += 1) {
             JSONCellType type = from.GetType(i);
             // skip keys of unknown type
@@ -805,11 +807,11 @@ methodmap JSON_Array < JSON_Object
                     this.PushBool(from.GetBool(i));
                 }
                 case JSON_Type_Object: {
-                    this.PushObject(from.GetObject(i));
+                    this.PushObject(deepCopy ? from.GetObject(i).DeepCopy() : from.GetObject(i));
                 }
             }
 
-            this.SetHidden(json_size + i, from.GetHidden(i));
+            this.SetHidden(current_size + i, from.GetHidden(i));
         }
 
         return true;

--- a/addons/sourcemod/scripting/include/json/object.inc
+++ b/addons/sourcemod/scripting/include/json/object.inc
@@ -406,7 +406,7 @@ methodmap JSON_Object < MetaStringMap
      * Retrieves the int64 stored at a key.
      *
      * @param key               Key to retrieve int64 value for.
-     * @param default_value     Value to return if the key does not exist.
+     * @param value             Value to store the int array in.
      * @return                  Value stored at key.
      */
     public bool GetInt64(const char[] key, int value[2])

--- a/addons/sourcemod/scripting/include/json/object.inc
+++ b/addons/sourcemod/scripting/include/json/object.inc
@@ -106,7 +106,7 @@ methodmap JSON_Object < MetaStringMap
      */
     public int Iterate()
     {
-        if (! this.OrderedKeys) {
+        if (! this.OrderedKeys && ! this.IsArray) {
             if (this.Snap != null) {
                 delete this.Snap;
                 this.Snap = null;

--- a/addons/sourcemod/scripting/json_test.sp
+++ b/addons/sourcemod/scripting/json_test.sp
@@ -439,6 +439,25 @@ void it_should_support_arrays_nested_in_arrays()
     json_cleanup_and_delete(arr);
 }
 
+void it_should_copy_null_keys()
+{
+    JSON_Object original = new JSON_Object();
+    original.SetObject("null_key", null);
+    original.SetString("non_null_key", "test_value");
+
+    JSON_Object copy = original.DeepCopy();
+    copy.SetString("non_null_key", "test_value_2");
+
+    _json_encode(original, JSON_ENCODE_PRETTY);
+    Test_AssertStringsEqual("output null copy original", json_encode_output, "{\"non_null_key\":\"test_value\",\"null_key\":null}");
+
+    _json_encode(copy, JSON_ENCODE_PRETTY);
+    Test_AssertStringsEqual("output null copy copy", json_encode_output, "{\"non_null_key\":\"test_value_2\",\"null_key\":null}");
+
+    json_cleanup_and_delete(original);
+    json_cleanup_and_delete(copy);
+}
+
 void it_should_support_basic_methodmaps()
 {
     Player player = new Player();
@@ -1273,6 +1292,7 @@ public void OnPluginStart()
     Test_Run("it_should_concat_arrays", it_should_concat_arrays);
     Test_Run("it_should_copy_flat_arrays", it_should_copy_flat_arrays);
     Test_Run("it_should_copy_flat_objects", it_should_copy_flat_objects);
+    Test_Run("it_should_copy_null_keys", it_should_copy_null_keys);
     Test_Run("it_should_shallow_copy_arrays", it_should_shallow_copy_arrays);
     Test_Run("it_should_shallow_copy_objects", it_should_shallow_copy_objects);
     Test_Run("it_should_preserve_ordered_keys_on_shallow_copy", it_should_preserve_ordered_keys_on_shallow_copy);


### PR DESCRIPTION
Hello

This is a proof-of-concept of changes that need to be applied (or, a suggestion) in order to fix https://github.com/clugg/sm-json/issues/34.

Basically, there were two problems here:

1. If you don't use ordered keys, you will leak `TrieSnapshot`s when DeepCopying via forwards in other plugins.
2. If you use ordered keys, `Merge` gets the objects wrong when deep copying, and you get invalid handle exceptions on cleanup.

I don't have a solution to preventing leaks if you don't use ordered keys, but at least in my case, I can control that on my end by enabling it on all objects I send via forwards, and receiving plugins can copy these objects without leaking, and those will then _also_ have ordered keys.

I don't fully understand *why* the merge logic doesn't work with ordered keys. I experienced it setting deep-copied properties (objects/arrays) multiple times on the same object, so you'd get objects like these (if you encode them out), which makes no sense:

```json
{
    "player": {
        "user_id": 3,
        "steamid": "76561197996426755",
        "side": "ct",
        "name": "Nyxi",
        "is_bot": false
    },
    "friendly_fire": true,
    "player": {
        "user_id": 3,
        "steamid": "76561197996426755",
        "side": "ct",
        "name": "Nyxi",
        "is_bot": false
    }
}
```
 - which should have been:
 
 ```json
 {
    "player": {
        "user_id": 3,
        "steamid": "76561197996426755",
        "side_int": 3,
        "side": "ct",
        "name": "Nyxi",
        "is_bot": false
    },
    "friendly_fire": true,
    "blind_duration": 4.742862
}
```

This PR is just a draft to illustrate how the problem can be solved. I essentially just duplicate the logic from shallow copy in the deep copy code, but deep copying objects directly then, which prevents the use of the Merge function. It's also technically faster since you don't need to loop the objects twice.

The "real" solution is probably to figure out why `Merge` doesn't work with ordered keys, but I just couldn't. It makes no sense to me. I should add that shallow-copying *does* work with ordered keys, but since you re-iterate the same object again in a deep copy, it goes wrong the second time you attempt to set keys - when overriding the shallow copied objects with new objects.